### PR TITLE
fix exporter package versions

### DIFF
--- a/packages/elasticsearch_exporter/packaging
+++ b/packages/elasticsearch_exporter/packaging
@@ -9,4 +9,4 @@ cp -a ${BOSH_COMPILE_TARGET}/common/* ${BOSH_INSTALL_TARGET}/common
 # Extract elasticsearch_exporter package
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
 tar xzvf ${BOSH_COMPILE_TARGET}/elasticsearch_exporter/elasticsearch_exporter-1.8.0.linux-amd64.tar.gz
-cp -a ${BOSH_COMPILE_TARGET}/elasticsearch_exporter-1.7.0.linux-amd64/* ${BOSH_INSTALL_TARGET}/bin
+cp -a ${BOSH_COMPILE_TARGET}/elasticsearch_exporter-1.8.0.linux-amd64/* ${BOSH_INSTALL_TARGET}/bin

--- a/packages/influxdb_exporter/packaging
+++ b/packages/influxdb_exporter/packaging
@@ -9,5 +9,5 @@ cp -a ${BOSH_COMPILE_TARGET}/common/* ${BOSH_INSTALL_TARGET}/common
 # Extract influxdb_exporter package
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
 tar xzvf ${BOSH_COMPILE_TARGET}/influxdb_exporter/influxdb_exporter-0.12.0.linux-amd64.tar.gz
-cp -a ${BOSH_COMPILE_TARGET}/influxdb_exporter-0.11.7.linux-amd64/* ${BOSH_INSTALL_TARGET}/bin
+cp -a ${BOSH_COMPILE_TARGET}/influxdb_exporter-0.12.0.linux-amd64/* ${BOSH_INSTALL_TARGET}/bin
 

--- a/packages/pushgateway/packaging
+++ b/packages/pushgateway/packaging
@@ -9,4 +9,4 @@ cp -a ${BOSH_COMPILE_TARGET}/common/* ${BOSH_INSTALL_TARGET}/common
 # Extract pushgateway package
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
 tar xzvf ${BOSH_COMPILE_TARGET}/pushgateway/pushgateway-1.10.0.linux-amd64.tar.gz
-cp -a ${BOSH_COMPILE_TARGET}/pushgateway-1.9.0.linux-amd64/* ${BOSH_INSTALL_TARGET}/bin
+cp -a ${BOSH_COMPILE_TARGET}/pushgateway-1.10.0.linux-amd64/* ${BOSH_INSTALL_TARGET}/bin

--- a/packages/redis_exporter/packaging
+++ b/packages/redis_exporter/packaging
@@ -9,4 +9,4 @@ cp -a ${BOSH_COMPILE_TARGET}/common/* ${BOSH_INSTALL_TARGET}/common
 # Extract redis_exporter package
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
 tar xzvf ${BOSH_COMPILE_TARGET}/redis_exporter/redis_exporter-v1.65.0.linux-amd64.tar.gz
-cp -a ${BOSH_COMPILE_TARGET}/redis_exporter-v1.62.0.linux-amd64/* ${BOSH_INSTALL_TARGET}/bin
+cp -a ${BOSH_COMPILE_TARGET}/redis_exporter-v1.65.0.linux-amd64/* ${BOSH_INSTALL_TARGET}/bin

--- a/packages/statsd_exporter/packaging
+++ b/packages/statsd_exporter/packaging
@@ -9,4 +9,4 @@ cp -a ${BOSH_COMPILE_TARGET}/common/* ${BOSH_INSTALL_TARGET}/common
 # Extract statsd_exporter package
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
 tar xzvf ${BOSH_COMPILE_TARGET}/statsd_exporter/statsd_exporter-0.28.0.linux-amd64.tar.gz
-cp -a ${BOSH_COMPILE_TARGET}/statsd_exporter-0.27.1.linux-amd64/* ${BOSH_INSTALL_TARGET}/bin
+cp -a ${BOSH_COMPILE_TARGET}/statsd_exporter-0.28.0.linux-amd64/* ${BOSH_INSTALL_TARGET}/bin


### PR DESCRIPTION
This pull request updates the packaging scripts for several exporters in the latest version of prometheus-boshrelease. The following changes have been made to ensure consistency between the extracted and copied package versions, preventing errors during the compilation process:

- **elasticsearch_exporter**: Updated to use version **1.8.0** for both extraction and copy commands.
- **influxdb_exporter**: Updated to use version **0.12.0** for both extraction and copy commands.
- **pushgateway**: Updated to use version **1.10.0** for both extraction and copy commands.
- **redis_exporter**: Updated to use version **1.65.0** for both extraction and copy commands.
- **statsd_exporter**: Updated to use version **0.28.0** for both extraction and copy commands.

These changes align the packaging scripts with the latest versions of the exporters, addressing issues such as "**No such file or directory**" errors during compilation.

Thank you for considering this update!

Sara Mendaci