### PR TITLE
Enable Grafana plugins installation

### DIFF
--- a/jobs/grafana/templates/bin/pre-start
+++ b/jobs/grafana/templates/bin/pre-start
@@ -6,11 +6,19 @@ set -eu
 mkdir -p /usr/share/fonts/freefont
 cp -a /var/vcap/packages/grafana/freefont/* /usr/share/fonts/freefont
 
+GRAFANA_STORE_DIR="/var/vcap/store/grafana"
+GRAFANA_PLUGIN_DIR="${GRAFANA_STORE_DIR}/plugins"
+
 # grafana is ran with bpm as user vcap
-mkdir -p /var/vcap/store/grafana
-chown vcap:vcap -R /var/vcap/store/grafana
+mkdir -p "${GRAFANA_PLUGIN_DIR}"
+chown vcap:vcap -R "${GRAFANA_STORE_DIR}"
+
+# link all plugins from grafana_plugins package
+find /var/vcap/packages/grafana_plugins/ -maxdepth 1 -mindepth 1 -type d \
+  -execdir test ! -L ${GRAFANA_PLUGIN_DIR}/{} \; \
+  -execdir ln -s /var/vcap/packages/grafana_plugins/{} ${GRAFANA_PLUGIN_DIR} \;
 
 echo "[$(date)] Calling 'prometheus-dashboards' ..."
-$(dirname $0)/prometheus-dashboards
+"$(dirname "$0")"/prometheus-dashboards
 
 exit 0

--- a/jobs/grafana/templates/config/grafana.ini
+++ b/jobs/grafana/templates/config/grafana.ini
@@ -32,7 +32,7 @@ temp_data_lifetime = <%= temp_data_lifetime %>
 logs = /var/vcap/sys/log/grafana
 
 # Directory where grafana will automatically scan and look for plugins
-plugins = /var/vcap/packages/grafana_plugins
+plugins = /var/vcap/store/grafana/plugins
 
 # folder that contains provisioning config files that grafana will apply on startup and while running.
 provisioning = /var/vcap/jobs/grafana/config/provisioning


### PR DESCRIPTION
Grafana plugins can be installed in the UI only if the plugin directory (defined in `grafana.ini`) is writable for `vcap` user. Currently the plugin directory is set to `/var/vcap/packages/grafana_plugins` which is writable by root only and not persistent. 

This change moves that directory to the persistent disk `/var/vcap/store` (so that plugins are not lost when the instance is recreated or upgraded) and links all existing plugins from `grafana_plugins` package to that directory.